### PR TITLE
refactor(): remove docker top level version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 networks:
   grafana:
 


### PR DESCRIPTION
## descrition
* remove docker compose `version` top level is obsolete

## how to review?
* check docker documentation
  * [documentation link1](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)
* run `docker compose up` & check that ALL is up
  <img width="1571" height="129" alt="image" src="https://github.com/user-attachments/assets/096e48f0-9d4b-4cd3-91fe-b84e3d0d70ad" />
